### PR TITLE
Fix by stripping whitespace characters around dashes from text string

### DIFF
--- a/metadata/extractAddress.py
+++ b/metadata/extractAddress.py
@@ -40,6 +40,7 @@ def getAddress(textRaw: str, typoSpellcheck: SpellChecker, adcache: any,
         "[a-zA-Z äÄöÖüÜß]+", lambda ele: " " + ele[0] + " ", textRaw)
     text: str = textString.replace(
         '\\', ' ').replace('\ ', '').replace('_', ' ')
+    text = "-".join(s.strip() for s in text.split("-"))  # Remove whitespaces around dashes
 
     # typoSpellcheck: SpellChecker = getSpellcheck()
 


### PR DESCRIPTION
Hi,

hier ein Fix für das " -str" Problem. Statt den Regex zu ändern, habe ich Whitespaces um Dash-Characters entfernt. Der Regex kann in schluesselregex.py auch angepasst werden:

adresse = (r'[.\w-]|\s){2,20}?(?:\s)?(?:strasse|str.|str|straße|ufer|allee|hof|weide|anlage|gasse|graben|gestell|chaussee|wache|weg|platz|promenade|pforte|pfad|damm|tor|brücke|berg)\s*\W??(?:\s)?\d{1}(?:\w{1,2}\.?)?(?:-|/\.?)?(?:\w{1,3}\.?)?')

Ich halte die Lösung über das Preprocessing des Strings aber für zukunftsfähiger.

Bitte testen, ob es funktioniert. Für einfache Test-Cases wie "Geschwister-Scholl -Str 38" geht es.